### PR TITLE
Problem: Signer trait does not support async signing

### DIFF
--- a/solo-machine-core/src/signer.rs
+++ b/solo-machine-core/src/signer.rs
@@ -6,6 +6,7 @@ mod mnemonic;
 pub use mnemonic::{AddressAlgo, MnemonicSigner};
 
 use anyhow::Result;
+use async_trait::async_trait;
 
 use crate::cosmos::crypto::PublicKey;
 
@@ -36,13 +37,15 @@ impl<T: ToPublicKey> ToPublicKey for &T {
 }
 
 /// This trait must be implemented by all the transaction signers (e.g. mnemonic, ledger, etc.)
-pub trait Signer: ToPublicKey {
+#[async_trait]
+pub trait Signer: ToPublicKey + Send + Sync {
     /// Signs the given message
-    fn sign(&self, message: &[u8]) -> Result<Vec<u8>>;
+    async fn sign(&self, message: &[u8]) -> Result<Vec<u8>>;
 }
 
+#[async_trait]
 impl<T: Signer> Signer for &T {
-    fn sign(&self, message: &[u8]) -> Result<Vec<u8>> {
-        (*self).sign(message)
+    async fn sign(&self, message: &[u8]) -> Result<Vec<u8>> {
+        (*self).sign(message).await
     }
 }

--- a/solo-machine-core/src/signer/mnemonic.rs
+++ b/solo-machine-core/src/signer/mnemonic.rs
@@ -1,6 +1,7 @@
 use std::str::FromStr;
 
 use anyhow::{anyhow, Context, Error, Result};
+use async_trait::async_trait;
 use bip32::{DerivationPath, ExtendedPrivateKey, Mnemonic};
 use k256::ecdsa::{signature::DigestSigner, Signature, SigningKey};
 use ripemd160::Digest;
@@ -76,8 +77,9 @@ impl ToPublicKey for MnemonicSigner {
     }
 }
 
+#[async_trait]
 impl Signer for MnemonicSigner {
-    fn sign(&self, message: &[u8]) -> Result<Vec<u8>> {
+    async fn sign(&self, message: &[u8]) -> Result<Vec<u8>> {
         let signing_key = self.get_signing_key()?;
 
         let signature: Signature = match self.algo {


### PR DESCRIPTION
Solution: Changed `sign` function of `Signer` trait to `async`. Fixes #25.