### PR TITLE
Problem: Signer `dylib` cannot spawn `async` tasks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -58,9 +58,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.42"
+version = "1.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "595d3cfa7a60d4555cb5067b99f07142a08ea778de5cf993f7b75c7d8fabc486"
+checksum = "28ae2b3dec75a406790005a200b1bd89785afc02517a00ca99ecfe093ee9e6cf"
 
 [[package]]
 name = "arrayvec"
@@ -172,9 +172,9 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "1.3.1"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2da1976d75adbe5fbc88130ecd119529cf1cc6a93ae1546d8696ee66f0d21af1"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitvec"
@@ -450,9 +450,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-bigint"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b32a398eb1ccfbe7e4f452bc749c44d38dd732e9a253f19da224c416f00ee7f4"
+checksum = "09910f0830248af4499907177608b81d640c8c404526f8770b87b765fbd8c9a5"
 dependencies = [
  "generic-array",
  "rand_core 0.6.3",
@@ -531,9 +531,9 @@ checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
 
 [[package]]
 name = "ecdsa"
-version = "0.12.3"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "713c32426287891008edb98f8b5c6abb2130aa043c93a818728fcda78606f274"
+checksum = "43ee23aa5b4f68c7a092b5c3beb25f50c406adc75e2363634f242f28ab255372"
 dependencies = [
  "der",
  "elliptic-curve",
@@ -1188,9 +1188,9 @@ checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 
 [[package]]
 name = "matches"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
+checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
 
 [[package]]
 name = "maybe-uninit"
@@ -1263,6 +1263,7 @@ dependencies = [
  "sha2",
  "sha3",
  "solo-machine-core",
+ "tokio",
 ]
 
 [[package]]
@@ -1999,9 +2000,9 @@ dependencies = [
 
 [[package]]
 name = "serde_cbor"
-version = "0.11.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e18acfa2f90e8b735b2836ab8d538de304cbb6729a7360729ea5a895d15a622"
+checksum = "2bef2ebfde456fb76bbcf9f59315333decc4fda0b2b44b420243c11e0f5ec1f5"
 dependencies = [
  "half",
  "serde",
@@ -2316,6 +2317,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "solo-machine-core",
+ "tokio",
 ]
 
 [[package]]
@@ -2585,9 +2587,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b7b349f11a7047e6d1276853e612d152f5e8a352c61917887cc2169e2366b4c"
+checksum = "01cf844b23c6131f624accf65ce0e4e9956a8bb329400ea5bcc26ae3a5c20b0b"
 dependencies = [
  "autocfg",
  "bytes",
@@ -2814,12 +2816,9 @@ checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeb8be209bb1c96b7c177c7420d26e04eccacb0eeae6b980e35fcb74678107e0"
-dependencies = [
- "matches",
-]
+checksum = "246f4c42e67e7a4e3c6106ff716a5d067d4132a642840b242e357e468a2a0085"
 
 [[package]]
 name = "unicode-normalization"

--- a/event-hooks/stdout-logger/Cargo.toml
+++ b/event-hooks/stdout-logger/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2018"
 crate-type = ["dylib"]
 
 [dependencies]
-anyhow = "1.0.42"
+anyhow = "1.0.43"
 async-trait = "0.1.51"
 solo-machine-core = { path = "../../solo-machine-core" }
+tokio = { version = "1.10.0", features = ["rt"] }

--- a/event-hooks/stdout-logger/src/lib.rs
+++ b/event-hooks/stdout-logger/src/lib.rs
@@ -4,6 +4,7 @@ use solo_machine_core::{
     event::{EventHandler, HandlerRegistrar},
     Event,
 };
+use tokio::runtime::Handle;
 
 struct StdoutLogger {}
 
@@ -16,6 +17,7 @@ impl EventHandler for StdoutLogger {
 }
 
 #[no_mangle]
-pub fn register_handler(registrar: &mut dyn HandlerRegistrar) {
-    registrar.register(Box::new(StdoutLogger {}))
+pub fn register_handler(_runtime: &Handle, registrar: &mut dyn HandlerRegistrar) -> Result<()> {
+    registrar.register(Box::new(StdoutLogger {}));
+    Ok(())
 }

--- a/signers/mnemonic-signer/Cargo.toml
+++ b/signers/mnemonic-signer/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 crate-type = ["dylib"]
 
 [dependencies]
-anyhow = "1.0.42"
+anyhow = "1.0.43"
 async-trait = "0.1.51"
 bip32 = { version = "0.2.1", features = ["bip39"] }
 k256 = { version = "0.9.6", features = ["ecdsa"] }
@@ -17,6 +17,7 @@ ripemd160 = "0.9.1"
 sha2 = "0.9.5"
 sha3 = { version = "0.9.1", optional = true }
 solo-machine-core = { path = "../../solo-machine-core" }
+tokio = { version = "1.10.0", features = ["rt"] }
 
 [features]
 default = []

--- a/signers/mnemonic-signer/src/lib.rs
+++ b/signers/mnemonic-signer/src/lib.rs
@@ -22,6 +22,7 @@ use solo_machine_core::{
     signer::{AddressAlgo, Message, SignerRegistrar},
     Signer, ToPublicKey,
 };
+use tokio::runtime::Handle;
 
 const DEFAULT_HD_PATH: &str = "m/44'/118'/0'/0/0";
 const DEFAULT_ACCOUNT_PREFIX: &str = "cosmos";
@@ -119,7 +120,7 @@ impl Signer for MnemonicSigner {
 }
 
 #[no_mangle]
-pub fn register_signer(registrar: &mut dyn SignerRegistrar) -> Result<()> {
+pub fn register_signer(_runtime: &Handle, registrar: &mut dyn SignerRegistrar) -> Result<()> {
     registrar.register(Arc::new(MnemonicSigner::from_env()?));
     Ok(())
 }

--- a/solo-machine-core/Cargo.toml
+++ b/solo-machine-core/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = "1.0.42"
+anyhow = "1.0.43"
 async-trait = "0.1.51"
 bech32 = "0.8.1"
 chrono = "0.4.19"
@@ -36,7 +36,7 @@ sqlx = { version = "0.5.5", features = [
 tendermint = "0.21.0"
 tendermint-light-client = "0.21.0"
 tendermint-rpc = { version = "0.21.0", features = ["http-client"] }
-tokio = { version = "1.9.0", features = ["sync"] }
+tokio = { version = "1.10.0", features = ["sync"] }
 tonic = "0.4.3"
 urlencoding = "2.1.0"
 

--- a/solo-machine/Cargo.toml
+++ b/solo-machine/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = "1.0.42"
+anyhow = "1.0.43"
 async-trait = "0.1.51"
 bip32 = { version = "0.2.1", features = ["bip39"] }
 cli-table = { version = "0.4.6", default-features = false, features = [
@@ -28,7 +28,7 @@ solo-machine-core = { path = "../solo-machine-core", features = [
 structopt = "0.3.22"
 tendermint = "0.21.0"
 termcolor = "1.1.2"
-tokio = { version = "1.9.0", features = ["fs", "macros", "rt-multi-thread"] }
+tokio = { version = "1.10.0", features = ["fs", "macros", "rt-multi-thread"] }
 tonic = "0.4.3"
 
 [features]

--- a/solo-machine/src/signer.rs
+++ b/solo-machine/src/signer.rs
@@ -3,6 +3,7 @@ use std::{convert::TryFrom, ffi::OsStr, path::PathBuf, sync::Arc};
 use anyhow::{anyhow, Context, Error, Result};
 use libloading::{Library, Symbol};
 use solo_machine_core::{signer::SignerRegistrar as ISignerRegistrar, Signer};
+use tokio::runtime::Handle;
 
 #[derive(Default)]
 pub struct SignerRegistrar {
@@ -31,12 +32,15 @@ impl SignerRegistrar {
             #[cfg(not(target_os = "linux"))]
             let library = Library::new(file).context("unable to load signer")?;
 
-            let register_fn: Symbol<unsafe extern "C" fn(&mut dyn ISignerRegistrar) -> Result<()>> =
-                library
-                    .get("register_signer".as_bytes())
-                    .context("unable to load `register_signer` function from signer")?;
+            let register_fn: Symbol<
+                unsafe extern "C" fn(&Handle, &mut dyn ISignerRegistrar) -> Result<()>,
+            > = library
+                .get("register_signer".as_bytes())
+                .context("unable to load `register_signer` function from signer")?;
 
-            register_fn(self)?;
+            let runtime = Handle::current();
+
+            register_fn(&runtime, self)?;
         }
 
         Ok(())


### PR DESCRIPTION
Solution: Pass `tokio::runtime::Handle` to dynamic libraries (both `Signer` and `EventHandler`). Fixes #35.