### PR TITLE
Problem: `ibc/Mint` and `ibc/Burn` gRPC responses does not contain transaction hash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -214,12 +214,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "build_const"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ae4235e6dac0694637c763029ecea1a2ec9e4e06ec2729bd21ba4d9c863eb7"
-
-[[package]]
 name = "bumpalo"
 version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -368,12 +362,18 @@ dependencies = [
 
 [[package]]
 name = "crc"
-version = "1.8.1"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d663548de7f5cca343f1e0a48d14dcfb0e9eb4e079ec58883b7251539fa10aeb"
+checksum = "10c2722795460108a7872e1cd933a85d6ec38abc4baecad51028f702da28889f"
 dependencies = [
- "build_const",
+ "crc-catalog",
 ]
+
+[[package]]
+name = "crc-catalog"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccaeedb56da03b09f598226e25e80088cb4cd25f316e6e4df7d695f0feeb1403"
 
 [[package]]
 name = "crc32fast"
@@ -691,6 +691,17 @@ dependencies = [
  "futures-core",
  "futures-task",
  "futures-util",
+]
+
+[[package]]
+name = "futures-intrusive"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62007592ac46aa7c2b6416f7deb9a8a8f63a01e0f1d6e1787d5630170db2b63e"
+dependencies = [
+ "futures-core",
+ "lock_api",
+ "parking_lot",
 ]
 
 [[package]]
@@ -1398,9 +1409,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
-version = "0.10.35"
+version = "0.10.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "549430950c79ae24e6d02e0b7404534ecf311d94cc9f861e9e4020187d13d885"
+checksum = "8d9facdb76fec0b73c406f125d44d86fdad818d66fef0531eec9233ca425ff4a"
 dependencies = [
  "bitflags",
  "cfg-if 1.0.0",
@@ -1418,9 +1429,9 @@ checksum = "28988d872ab76095a6e6ac88d99b54fd267702734fd7ffe610ca27f533ddb95a"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.65"
+version = "0.9.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a7907e3bfa08bb85105209cdfcb6c63d109f8f6c1ed6ca318fff5c1853fbc1d"
+checksum = "1996d2d305e561b70d1ee0c53f1542833f4e1ac6ce9a6708b6ff2738ca67dc82"
 dependencies = [
  "autocfg",
  "cc",
@@ -2217,9 +2228,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx"
-version = "0.5.5"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba82f79b31f30acebf19905bcd8b978f46891b9d0723f578447361a8910b6584"
+checksum = "b977121ecc75cadd442a6a8c600f5ded6d7117a46d55ed417a815bd94b2af237"
 dependencies = [
  "sqlx-core",
  "sqlx-macros",
@@ -2227,9 +2238,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx-core"
-version = "0.5.5"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f23af36748ec8ea8d49ef8499839907be41b0b1178a4e82b8cb45d29f531dc9"
+checksum = "6da11206ae9ba3ececf83d44aef533c0d8176ae430cfaa14b408ce8b6bc4ab4b"
 dependencies = [
  "ahash",
  "atoi",
@@ -2244,6 +2255,7 @@ dependencies = [
  "either",
  "futures-channel",
  "futures-core",
+ "futures-intrusive",
  "futures-util",
  "hashlink",
  "hex",
@@ -2273,9 +2285,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx-macros"
-version = "0.5.5"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47e4a2349d1ffd60a03ca0de3f116ba55d7f406e55a0d84c64a5590866d94c06"
+checksum = "419f9005ad3b065ab4e774361b0d56a24e8e3dc9b2c9ddeaf018b5fdc1166ec2"
 dependencies = [
  "dotenv",
  "either",
@@ -2294,9 +2306,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx-rt"
-version = "0.5.5"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8199b421ecf3493ee9ef3e7bc90c904844cfb2ea7ea2f57347a93f52bfd3e057"
+checksum = "52d39baa13314f936c5991429b0b656980f52d23dfb15078bbea2c51f5086eeb"
 dependencies = [
  "once_cell",
  "tokio",
@@ -2777,9 +2789,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9ff14f98b1a4b289c6248a023c1c2fa1491062964e9fed67ab29c4e4da4a052"
+checksum = "2ca517f43f0fb96e0c3072ed5c275fe5eece87e8cb52f4a77b69226d3b1c9df8"
 dependencies = [
  "lazy_static",
 ]
@@ -3028,9 +3040,9 @@ dependencies = [
 
 [[package]]
 name = "whoami"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4abacf325c958dfeaf1046931d37f2a901b6dfe0968ee965a29e94c6766b2af6"
+checksum = "f7741161a40200a867c96dfa5574544efa4178cf4c8f770b62dd1cc0362d7ae1"
 dependencies = [
  "wasm-bindgen",
  "web-sys",

--- a/solo-machine-core/Cargo.toml
+++ b/solo-machine-core/Cargo.toml
@@ -26,7 +26,7 @@ serde = { version = "1.0.127", features = ["derive"] }
 serde_json = "1.0.66"
 sha2 = "0.9.5"
 sha3 = { version = "0.9.1", optional = true }
-sqlx = { version = "0.5.5", features = [
+sqlx = { version = "0.5.6", features = [
     "json",
     "macros",
     "runtime-tokio-rustls",

--- a/solo-machine-core/src/service/ibc_service.rs
+++ b/solo-machine-core/src/service/ibc_service.rs
@@ -272,7 +272,7 @@ impl IbcService {
         denom: Identifier,
         receiver: Option<String>,
         memo: String,
-    ) -> Result<()> {
+    ) -> Result<String> {
         let mut chain = chain::get_chain(&self.db_pool, &chain_id)
             .await?
             .ok_or_else(|| anyhow!("chain details for {} not found", chain_id))?;
@@ -342,11 +342,11 @@ impl IbcService {
                     to_address: receiver,
                     amount,
                     denom,
-                    transaction_hash,
+                    transaction_hash: transaction_hash.clone(),
                 },
             )?;
 
-            Ok(())
+            Ok(transaction_hash)
         } else {
             let error = extract_attribute(
                 &response.deliver_tx.events,
@@ -372,7 +372,7 @@ impl IbcService {
         denom: Identifier,
         receiver: Option<String>,
         memo: String,
-    ) -> Result<()> {
+    ) -> Result<String> {
         let mut chain = chain::get_chain(&self.db_pool, &chain_id)
             .await?
             .ok_or_else(|| anyhow!("chain details for {} not found", chain_id))?;
@@ -449,7 +449,7 @@ impl IbcService {
                 from_address: address,
                 amount,
                 denom,
-                transaction_hash,
+                transaction_hash: transaction_hash.clone(),
             },
         )?;
 
@@ -474,7 +474,7 @@ impl IbcService {
             )?;
         }
 
-        Ok(())
+        Ok(transaction_hash)
     }
 
     /// Updates signer for future IBC transactions

--- a/solo-machine/proto/ibc.proto
+++ b/solo-machine/proto/ibc.proto
@@ -45,7 +45,10 @@ message MintRequest {
     optional string receiver_address = 6;
 }
 
-message MintResponse {}
+message MintResponse {
+    // Hash of transaction on IBC enabled chain (in hex)
+    string transaction_hash = 1;
+}
 
 message BurnRequest {
     // Chain ID of IBC enabled chain to send to
@@ -62,7 +65,10 @@ message BurnRequest {
     optional string receiver_address = 6;
 }
 
-message BurnResponse {}
+message BurnResponse {
+    // Hash of transaction on IBC enabled chain (in hex)
+    string transaction_hash = 1;
+}
 
 message UpdateSignerRequest {
     // Chain ID of IBC enabled chain

--- a/solo-machine/src/command/ibc.rs
+++ b/solo-machine/src/command/ibc.rs
@@ -121,11 +121,10 @@ impl IbcCommand {
                 receiver,
                 memo,
                 request_id,
-            } => {
-                ibc_service
-                    .mint(signer, chain_id, request_id, amount, denom, receiver, memo)
-                    .await
-            }
+            } => ibc_service
+                .mint(signer, chain_id, request_id, amount, denom, receiver, memo)
+                .await
+                .map(|_| ()),
             Self::Burn {
                 chain_id,
                 amount,
@@ -133,11 +132,10 @@ impl IbcCommand {
                 receiver,
                 memo,
                 request_id,
-            } => {
-                ibc_service
-                    .burn(signer, chain_id, request_id, amount, denom, receiver, memo)
-                    .await
-            }
+            } => ibc_service
+                .burn(signer, chain_id, request_id, amount, denom, receiver, memo)
+                .await
+                .map(|_| ()),
             Self::UpdateSigner {
                 chain_id,
                 new_public_key,

--- a/solo-machine/src/server/ibc.rs
+++ b/solo-machine/src/server/ibc.rs
@@ -74,7 +74,8 @@ where
             .map_err(|err: anyhow::Error| Status::invalid_argument(err.to_string()))?;
         let receiver = request.receiver_address;
 
-        self.core_service
+        let transaction_hash = self
+            .core_service
             .mint(
                 &self.signer,
                 chain_id,
@@ -87,7 +88,7 @@ where
             .await
             .map_err(|err| Status::internal(err.to_string()))?;
 
-        Ok(Response::new(MintResponse {}))
+        Ok(Response::new(MintResponse { transaction_hash }))
     }
 
     async fn burn(&self, request: Request<BurnRequest>) -> Result<Response<BurnResponse>, Status> {
@@ -106,7 +107,8 @@ where
             .map_err(|err: anyhow::Error| Status::invalid_argument(err.to_string()))?;
         let receiver = request.receiver_address;
 
-        self.core_service
+        let transaction_hash = self
+            .core_service
             .burn(
                 &self.signer,
                 chain_id,
@@ -119,7 +121,7 @@ where
             .await
             .map_err(|err| Status::internal(err.to_string()))?;
 
-        Ok(Response::new(BurnResponse {}))
+        Ok(Response::new(BurnResponse { transaction_hash }))
     }
 
     async fn update_signer(


### PR DESCRIPTION
Solution: Added transaction hash in responses of `ibc/Mint` and `ibc/Burn`. Fixes #38.