### PR TITLE
Problem: Solo machine overwrites connection details when connect is called twice

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -997,9 +997,9 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.4.1"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3a87b616e37e93c22fb19bcd386f02f3af5ea98a25670ad0fce773de23c5e68"
+checksum = "7ba8d84e9efea6aedae6fed9b6d9cfcaac6c53992b437d79a87a549d5537fea9"
 
 [[package]]
 name = "httpdate"
@@ -1262,9 +1262,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.4.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b16bd47d9e329435e309c58469fe0791c2d0d1ba96ec0954152a5ae2b04387dc"
+checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
 
 [[package]]
 name = "memoffset"
@@ -1439,9 +1439,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.26.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c55827317fb4c08822499848a14237d2874d6f139828893017237e7ab93eb386"
+checksum = "ee2766204889d09937d00bfbb7fec56bb2a199e2ade963cab19185d8a6104c7c"
 dependencies = [
  "memchr",
 ]

--- a/solo-machine-core/src/service/ibc_service.rs
+++ b/solo-machine-core/src/service/ibc_service.rs
@@ -77,6 +77,7 @@ impl IbcService {
         signer: impl Signer,
         chain_id: ChainId,
         memo: String,
+        force: bool,
     ) -> Result<()> {
         let mut transaction = self
             .db_pool
@@ -87,6 +88,13 @@ impl IbcService {
         let mut chain = chain::get_chain(&mut transaction, &chain_id)
             .await?
             .ok_or_else(|| anyhow!("chain details for {} not found", chain_id))?;
+
+        if !force {
+            ensure!(
+                chain.connection_details.is_none(),
+                "connection is already established with given chain"
+            );
+        }
 
         let rpc_client = HttpClient::new(chain.config.rpc_addr.as_str())
             .context("unable to connect to rpc client")?;

--- a/solo-machine/proto/ibc.proto
+++ b/solo-machine/proto/ibc.proto
@@ -26,6 +26,8 @@ message ConnectRequest {
     string chain_id = 1;
     // Memo value to be used in cosmos sdk transaction
     optional string memo = 2;
+    // Force create a new connection even if one already exists
+    bool force = 3;
 }
 
 message ConnectResponse {}

--- a/solo-machine/src/command/ibc.rs
+++ b/solo-machine/src/command/ibc.rs
@@ -29,6 +29,9 @@ pub enum IbcCommand {
             hide_env_values = true
         )]
         memo: String,
+        /// Force create a new connection even if one already exists
+        #[structopt(long)]
+        force: bool,
     },
     /// Mint some tokens on IBC enabled chain
     Mint {
@@ -113,7 +116,11 @@ impl IbcCommand {
         let ibc_service = IbcService::new_with_notifier(db_pool, sender);
 
         match self {
-            Self::Connect { chain_id, memo } => ibc_service.connect(signer, chain_id, memo).await,
+            Self::Connect {
+                chain_id,
+                memo,
+                force,
+            } => ibc_service.connect(signer, chain_id, memo, force).await,
             Self::Mint {
                 chain_id,
                 amount,

--- a/solo-machine/src/server/ibc.rs
+++ b/solo-machine/src/server/ibc.rs
@@ -49,9 +49,10 @@ where
             .parse()
             .map_err(|err: anyhow::Error| Status::invalid_argument(err.to_string()))?;
         let memo = request.memo.unwrap_or_else(|| DEFAULT_MEMO.to_owned());
+        let force = request.force;
 
         self.core_service
-            .connect(&self.signer, chain_id, memo)
+            .connect(&self.signer, chain_id, memo, force)
             .await
             .map_err(|err| Status::internal(err.to_string()))?;
 


### PR DESCRIPTION
Solution: Added a check to ensure that a connection does not already exists. Also added a `force` argument to force create new connection even when one already exists. Fixes #41.