### PR TITLE
Problem: Solo machine's transfer packet has different wire format

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -341,9 +341,9 @@ checksum = "ea221b5284a47e40033bf9b66f35f984ec0ea2931eb03505246cd27a963f981b"
 
 [[package]]
 name = "cosmos-sdk-proto"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4cf3fbbaea789be39b1ef4c6ff9a55df0d682cfddaa765dcbbbd04f2c50c06a"
+checksum = "caa67dafbfb5eb8c88cc741e24e4070dd85a566a9f5c3dac13d5540ce3178107"
 dependencies = [
  "prost 0.7.0",
  "prost-types 0.7.0",
@@ -1028,9 +1028,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.11"
+version = "0.14.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b61cf2d1aebcf6e6352c97b81dc2244ca29194be1b276f5d8ad5c6330fffb11"
+checksum = "13f67199e765030fa08fe0bd581af683f0d5bc04ea09c2b1102012c5fb90e7fd"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1944,9 +1944,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.20"
+version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dead70b0b5e03e9c814bcb6b01e03e68f7c57a80aa48c72ec92152ab3e818d49"
+checksum = "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342"
 
 [[package]]
 name = "rustc_version"
@@ -2680,9 +2680,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.10.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01cf844b23c6131f624accf65ce0e4e9956a8bb329400ea5bcc26ae3a5c20b0b"
+checksum = "92036be488bb6594459f2e03b60e42df6f937fe6ca5c5ffdcb539c6b84dc40f5"
 dependencies = [
  "autocfg",
  "bytes",

--- a/solo-machine-core/Cargo.toml
+++ b/solo-machine-core/Cargo.toml
@@ -11,7 +11,7 @@ anyhow = "1.0.43"
 async-trait = "0.1.51"
 bech32 = "0.8.1"
 chrono = "0.4.19"
-cosmos-sdk-proto = "0.6.1"
+cosmos-sdk-proto = "0.6.2"
 ed25519-dalek = "1.0.1"
 hex = { version = "0.4.3", features = ["serde"] }
 k256 = { version = "0.9.6", features = ["ecdsa"] }
@@ -36,7 +36,7 @@ sqlx = { version = "0.5.7", features = [
 tendermint = "0.21.0"
 tendermint-light-client = "0.21.0"
 tendermint-rpc = { version = "0.21.0", features = ["http-client"] }
-tokio = { version = "1.10.0", features = ["sync"] }
+tokio = { version = "1.10.1", features = ["sync"] }
 tonic = { version = "0.4.3", features = ["tls", "tls-roots"] }
 urlencoding = "2.1.0"
 

--- a/solo-machine-core/src/transaction_builder.rs
+++ b/solo-machine-core/src/transaction_builder.rs
@@ -57,7 +57,7 @@ use cosmos_sdk_proto::{
     },
 };
 use prost_types::{Any, Duration};
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 use serde_json::json;
 use sqlx::{Executor, Transaction};
 use tendermint::block::Header;
@@ -366,7 +366,7 @@ where
 
     let packet_data = TokenTransferPacketData {
         denom: denom.to_string(),
-        amount,
+        amount: amount.to_string(),
         sender: sender.clone(),
         receiver,
     };
@@ -972,10 +972,12 @@ fn to_u64_timestamp(timestamp: DateTime<Utc>) -> Result<u64> {
         .context("unable to convert unix timestamp to u64")
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize)]
 pub struct TokenTransferPacketData {
     pub denom: String,
-    pub amount: u64,
+    // Ideally `amount` should be `u64` but `ibc-go` uses `protojson` which encodes `uint64` into `string`. So, using
+    // `String` here to keep consistent wire format.
+    pub amount: String,
     pub sender: String,
     pub receiver: String,
 }

--- a/solo-machine/Cargo.toml
+++ b/solo-machine/Cargo.toml
@@ -31,7 +31,7 @@ solo-machine-core = { path = "../solo-machine-core", features = [
 structopt = "0.3.22"
 tendermint = "0.21.0"
 termcolor = "1.1.2"
-tokio = { version = "1.10.0", features = ["fs", "macros", "rt-multi-thread"] }
+tokio = { version = "1.10.1", features = ["fs", "macros", "rt-multi-thread"] }
 tonic = { version = "0.4.3", features = ["tls", "tls-roots"] }
 
 [features]


### PR DESCRIPTION
Solution: Changed amount in `TokenTransferPacketData` to `String`. Fixes #53.