### PR TITLE
Problem: Cannot pass `request_id` in `UpdateSigner` and `Connect` commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -221,9 +221,9 @@ checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
 
 [[package]]
 name = "cc"
-version = "1.0.69"
+version = "1.0.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e70cc2f62c6ce1868963827bd677764c62d07c3d9a3e1fb1177ee1a9ab199eb2"
+checksum = "d26a6ce4b6a484fa3edb70f7efa6fc430fd2b87285fe8b84304fd0936faa0dc0"
 
 [[package]]
 name = "cfg-if"
@@ -341,9 +341,9 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.1.5"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66c99696f6c9dd7f35d486b9d04d7e6e202aa3e8c40d553f2fdf5e7e0c6a71ef"
+checksum = "95059428f66df56b63431fdb4e1947ed2190586af5c5a8a8b71122bdf5a7f469"
 dependencies = [
  "libc",
 ]
@@ -678,9 +678,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1adc00f486adfc9ce99f77d717836f0c5aa84965eb0b4f051f4e83f7cab53f8b"
+checksum = "a12aa0eb539080d55c3f2d45a67c3b58b6b0773c1a3ca2dfec66d58c97fd66ca"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -693,9 +693,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74ed2411805f6e4e3d9bc904c95d5d423b89b3b25dc0250aa74729de20629ff9"
+checksum = "5da6ba8c3bb3c165d3c7319fc1cc8304facf1fb8db99c5de877183c08a273888"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -703,15 +703,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af51b1b4a7fdff033703db39de8802c673eb91855f2e0d47dcf3bf2c0ef01f99"
+checksum = "88d1c26957f23603395cd326b0ffe64124b818f4449552f960d815cfba83a53d"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d0d535a57b87e1ae31437b892713aee90cd2d7b0ee48727cd11fc72ef54761c"
+checksum = "45025be030969d763025784f7f355043dc6bc74093e4ecc5000ca4dc50d8745c"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -731,15 +731,15 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b0e06c393068f3a6ef246c75cdca793d6a46347e75286933e5e75fd2fd11582"
+checksum = "522de2a0fe3e380f1bc577ba0474108faf3f6b18321dbf60b3b9c39a75073377"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c54913bae956fb8df7f4dc6fc90362aa72e69148e3f39041fbe8742d21e0ac57"
+checksum = "18e4a4b95cea4b4ccbcf1c5675ca7c4ee4e9e75eb79944d07defde18068f79bb"
 dependencies = [
  "autocfg",
  "proc-macro-hack",
@@ -750,21 +750,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0f30aaa67363d119812743aa5f33c201a7a66329f97d1a887022971feea4b53"
+checksum = "36ea153c13024fe480590b3e3d4cad89a0cfacecc24577b68f86c6ced9c2bc11"
 
 [[package]]
 name = "futures-task"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbe54a98670017f3be909561f6ad13e810d9a51f3f061b902062ca3da80799f2"
+checksum = "1d3d00f4eddb73e498a54394f228cd55853bdf059259e8e7bc6e69d408892e99"
 
 [[package]]
 name = "futures-util"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67eb846bfd58e44a8481a00049e82c43e0ccb5d61f8dc071057cb19249dd4d78"
+checksum = "36568465210a3a6ee45e1f165136d68671471a501e632e9a98d96872222b5481"
 dependencies = [
  "autocfg",
  "futures-channel",
@@ -1197,9 +1197,9 @@ dependencies = [
 
 [[package]]
 name = "lock_api"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0382880606dff6d15c9476c416d18690b72742aa7b605bb6dd6ec9030fbf07eb"
+checksum = "712a4d093c9976e24e7dbca41db895dabcbac38eb5f4045393d17a95bdfb1109"
 dependencies = [
  "scopeguard",
 ]
@@ -1360,36 +1360,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "num"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43db66d1170d347f9a065114077f7dccb00c1b9478c89384490a3425279a4606"
-dependencies = [
- "num-bigint",
- "num-complex",
- "num-integer",
- "num-iter",
- "num-rational",
- "num-traits",
-]
-
-[[package]]
 name = "num-bigint"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e0d047c1062aa51e256408c560894e5251f08925980e53cf1aa5bd00eec6512"
+checksum = "76e97c412795abf6c24ba30055a8f20642ea57ca12875220b854cfa501bf1e48"
 dependencies = [
  "autocfg",
  "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "num-complex"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26873667bbbb7c5182d4a37c1add32cdf09f841af72da53318fdb81543c15085"
-dependencies = [
  "num-traits",
 ]
 
@@ -1411,17 +1388,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
 dependencies = [
  "autocfg",
- "num-traits",
-]
-
-[[package]]
-name = "num-iter"
-version = "0.1.42"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2021c8337a54d21aca0d59a92577a029af9431cb59b909b03252b9c164fad59"
-dependencies = [
- "autocfg",
- "num-integer",
  "num-traits",
 ]
 
@@ -1459,9 +1425,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.26.1"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee2766204889d09937d00bfbb7fec56bb2a199e2ade963cab19185d8a6104c7c"
+checksum = "39f37e50073ccad23b6d09bcb5b263f4e76d3bb6038e4a3c08e52162ffa8abc2"
 dependencies = [
  "memchr",
 ]
@@ -1513,9 +1479,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
-version = "0.11.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d7744ac029df22dca6284efe4e898991d28e3085c706c972bcd7da4a27a15eb"
+checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
 dependencies = [
  "instant",
  "lock_api",
@@ -1524,9 +1490,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.8.3"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7a782938e745763fe6907fc6ba86946d72f49fe7e21de074e08128a99fb018"
+checksum = "d76e8e1493bcac0d2766c42737f34458f1c8c50c0d23bcb24ea953affb273216"
 dependencies = [
  "cfg-if 1.0.0",
  "instant",
@@ -1662,9 +1628,9 @@ checksum = "bc881b2c22681370c6a780e47af9840ef841837bc98118431d4e1868bd0c1086"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.28"
+version = "1.0.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c7ed8b8c7b886ea3ed7dde405212185f423ab44682667c8c6dd14aa1d9f6612"
+checksum = "b9f5105d4fdaab20335ca9565e106a5d9b82b6219b5ba735731124ac6711d23d"
 dependencies = [
  "unicode-xid",
 ]
@@ -2026,23 +1992,22 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.4.0"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b9bd29cdffb8875b04f71c51058f940cf4e390bbfd2ce669c4f22cd70b492a5"
+checksum = "525bc1abfda2e1998d152c45cf13e696f76d0a4972310b22fac1658b05df7c87"
 dependencies = [
  "bitflags",
  "core-foundation",
  "core-foundation-sys",
  "libc",
- "num",
  "security-framework-sys",
 ]
 
 [[package]]
 name = "security-framework-sys"
-version = "2.4.0"
+version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19133a286e494cc3311c165c4676ccb1fd47bed45b55f9d71fbd784ad4cea6f8"
+checksum = "a9dd14d83160b528b7bfd66439110573efcfbe281b17fc2ca9f39f550d619c7e"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -2068,9 +2033,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.129"
+version = "1.0.130"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1f72836d2aa753853178eda473a3b9d8e4eefdaf20523b919677e6de489f8f1"
+checksum = "f12d06de37cf59146fbdecab66aa99f9fe4f78722e3607577a5375d66bd0c913"
 dependencies = [
  "serde_derive",
 ]
@@ -2096,9 +2061,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.129"
+version = "1.0.130"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e57ae87ad533d9a56427558b516d0adac283614e347abf85b0dc0cbbf0a249f3"
+checksum = "d7bc1a1ab1961464eae040d96713baa5a724a8152c1222492465b54322ec508b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2107,9 +2072,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.66"
+version = "1.0.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "336b10da19a12ad094b59d870ebde26a45402e5b470add4b5fd03c5048a32127"
+checksum = "a7f9e390c27c3c0ce8bc5d725f6e4d30a29d26659494aa4b17535f7522c5c950"
 dependencies = [
  "indexmap",
  "itoa",
@@ -2130,9 +2095,9 @@ dependencies = [
 
 [[package]]
 name = "sha-1"
-version = "0.9.7"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a0c8611594e2ab4ebbf06ec7cbbf0a99450b8570e96cbf5188b5d5f6ef18d81"
+checksum = "99cd6713db3cf16b6c84e06321e049a9b9f699826e16096d23bbcc44d15d51a6"
 dependencies = [
  "block-buffer",
  "cfg-if 1.0.0",
@@ -2143,9 +2108,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.9.5"
+version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b362ae5752fd2137731f9fa25fd4d9058af34666ca1966fb969119cc35719f12"
+checksum = "9204c41a1597a8c5af23c82d1c921cb01ec0a4c59e07a9c7306062829a3903f3"
 dependencies = [
  "block-buffer",
  "cfg-if 1.0.0",
@@ -2433,9 +2398,9 @@ checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "structopt"
-version = "0.3.22"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69b041cdcb67226aca307e6e7be44c8806423d83e018bd662360a93dabce4d71"
+checksum = "bf9d950ef167e25e0bdb073cf1d68e9ad2795ac826f2f3f59647817cf23c0bfa"
 dependencies = [
  "clap",
  "lazy_static",
@@ -2444,9 +2409,9 @@ dependencies = [
 
 [[package]]
 name = "structopt-derive"
-version = "0.4.15"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7813934aecf5f51a54775e00068c237de98489463968231a51746bbbc03f9c10"
+checksum = "134d838a2c9943ac3125cf6df165eda53493451b719f3255b2a26b85f772d0ba"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -2630,18 +2595,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.26"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93119e4feac1cbe6c798c34d3a53ea0026b0b1de6a120deef895137c0529bfe2"
+checksum = "283d5230e63df9608ac7d9691adc1dfb6e701225436eb64d0b9a7f0a5a04f6ec"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.26"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "060d69a0afe7796bf42e9e2ff91f5ee691fb15c53d38b4b62a9a53eb23164745"
+checksum = "fa3884228611f5cd3608e2d409bf7dce832e4eb3135e3f11addbd7e41bd68e71"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2676,9 +2641,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.10.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92036be488bb6594459f2e03b60e42df6f937fe6ca5c5ffdcb539c6b84dc40f5"
+checksum = "b4efe6fc2395938c8155973d7be49fe8d03a843726e285e100a8a383cc0154ce"
 dependencies = [
  "autocfg",
  "bytes",

--- a/signers/mnemonic-signer/Cargo.toml
+++ b/signers/mnemonic-signer/Cargo.toml
@@ -14,7 +14,7 @@ async-trait = "0.1.51"
 bip32 = { version = "0.2.1", features = ["bip39"] }
 k256 = { version = "0.9.6", features = ["ecdsa"] }
 ripemd160 = "0.9.1"
-sha2 = "0.9.5"
+sha2 = "0.9.6"
 sha3 = { version = "0.9.1", optional = true }
 solo-machine-core = { path = "../../solo-machine-core" }
 

--- a/solo-machine-core/Cargo.toml
+++ b/solo-machine-core/Cargo.toml
@@ -22,9 +22,9 @@ rand = "0.8.4"
 regex = "1.5.4"
 ripemd160 = "0.9.1"
 rust_decimal = "1.15.0"
-serde = { version = "1.0.129", features = ["derive"] }
-serde_json = "1.0.66"
-sha2 = "0.9.5"
+serde = { version = "1.0.130", features = ["derive"] }
+serde_json = "1.0.67"
+sha2 = "0.9.6"
 sha3 = { version = "0.9.1", optional = true }
 sqlx = { version = "0.5.7", features = [
     "json",
@@ -36,7 +36,7 @@ sqlx = { version = "0.5.7", features = [
 tendermint = "0.21.0"
 tendermint-light-client = "0.21.0"
 tendermint-rpc = { version = "0.21.0", features = ["http-client"] }
-tokio = { version = "1.10.1", features = ["sync"] }
+tokio = { version = "1.11.0", features = ["sync"] }
 tonic = { version = "0.4.3", features = ["tls", "tls-roots"] }
 urlencoding = "2.1.0"
 

--- a/solo-machine/Cargo.toml
+++ b/solo-machine/Cargo.toml
@@ -24,14 +24,14 @@ num-rational = "0.4.0"
 prost = "0.7.0"
 prost-types = "0.7.0"
 rust_decimal = "1.15.0"
-serde_json = "1.0.66"
+serde_json = "1.0.67"
 solo-machine-core = { path = "../solo-machine-core", features = [
     "solomachine-v2",
 ] }
-structopt = "0.3.22"
+structopt = "0.3.23"
 tendermint = "0.21.0"
 termcolor = "1.1.2"
-tokio = { version = "1.10.1", features = ["fs", "macros", "rt-multi-thread"] }
+tokio = { version = "1.11.0", features = ["fs", "macros", "rt-multi-thread"] }
 tonic = { version = "0.4.3", features = ["tls", "tls-roots"] }
 
 [features]

--- a/solo-machine/proto/ibc.proto
+++ b/solo-machine/proto/ibc.proto
@@ -24,10 +24,12 @@ service Ibc {
 message ConnectRequest {
     // Chain ID of IBC enabled chain to connect to
     string chain_id = 1;
+    // An optional request ID for tracking purposes
+    optional string request_id = 2;
     // Memo value to be used in cosmos sdk transaction
-    optional string memo = 2;
+    optional string memo = 3;
     // Force create a new connection even if one already exists
-    bool force = 3;
+    bool force = 4;
 }
 
 message ConnectResponse {}
@@ -73,12 +75,14 @@ message BurnResponse {
 message UpdateSignerRequest {
     // Chain ID of IBC enabled chain
     string chain_id = 1;
+    // An optional request ID for tracking purposes
+    optional string request_id = 2;
     // Memo value to be used in cosmos sdk transaction
-    optional string memo = 2;
+    optional string memo = 3;
     // Hex encoded public key
-    string new_public_key = 3;
+    string new_public_key = 4;
     // Type of public key
-    optional string public_key_algo = 4;
+    optional string public_key_algo = 5;
 }
 
 message UpdateSignerResponse {}

--- a/solo-machine/src/command/ibc.rs
+++ b/solo-machine/src/command/ibc.rs
@@ -29,6 +29,9 @@ pub enum IbcCommand {
             hide_env_values = true
         )]
         memo: String,
+        /// Optional request ID (for tracking purposes)
+        #[structopt(long)]
+        request_id: Option<String>,
         /// Force create a new connection even if one already exists
         #[structopt(long)]
         force: bool,
@@ -93,6 +96,9 @@ pub enum IbcCommand {
             hide_env_values = true
         )]
         memo: String,
+        /// Optional request ID (for tracking purposes)
+        #[structopt(long)]
+        request_id: Option<String>,
     },
     /// Check history of operations on solo machine
     History {
@@ -117,8 +123,13 @@ impl IbcCommand {
             Self::Connect {
                 chain_id,
                 memo,
+                request_id,
                 force,
-            } => ibc_service.connect(signer, chain_id, memo, force).await,
+            } => {
+                ibc_service
+                    .connect(signer, chain_id, request_id, memo, force)
+                    .await
+            }
             Self::Mint {
                 chain_id,
                 amount,
@@ -145,6 +156,7 @@ impl IbcCommand {
                 new_public_key,
                 public_key_algo,
                 memo,
+                request_id,
             } => {
                 let new_public_key_bytes =
                     hex::decode(&new_public_key).context("unable to decode hex bytes")?;
@@ -159,7 +171,7 @@ impl IbcCommand {
                 };
 
                 ibc_service
-                    .update_signer(signer, chain_id, new_public_key, memo)
+                    .update_signer(signer, chain_id, request_id, new_public_key, memo)
                     .await
             }
             Self::History { limit, offset } => {

--- a/solo-machine/src/server/ibc.rs
+++ b/solo-machine/src/server/ibc.rs
@@ -49,10 +49,11 @@ where
             .parse()
             .map_err(|err: anyhow::Error| Status::invalid_argument(err.to_string()))?;
         let memo = request.memo.unwrap_or_else(|| DEFAULT_MEMO.to_owned());
+        let request_id = request.request_id;
         let force = request.force;
 
         self.core_service
-            .connect(&self.signer, chain_id, memo, force)
+            .connect(&self.signer, chain_id, request_id, memo, force)
             .await
             .map_err(|err| {
                 log::error!("{}", err);
@@ -136,6 +137,8 @@ where
             .parse()
             .map_err(|err: anyhow::Error| Status::invalid_argument(err.to_string()))?;
 
+        let request_id = request.request_id;
+
         let memo = request.memo.unwrap_or_else(|| DEFAULT_MEMO.to_owned());
 
         let new_public_key_bytes = hex::decode(&request.new_public_key)
@@ -158,7 +161,7 @@ where
         };
 
         self.core_service
-            .update_signer(&self.signer, chain_id, new_public_key, memo)
+            .update_signer(&self.signer, chain_id, request_id, new_public_key, memo)
             .await
             .map_err(|err| {
                 log::error!("{}", err);


### PR DESCRIPTION
Solution: Added CLI and gRPC arguments to pass `request_id` in `UpdateSigner` and `Connect` commands. Fixes #67.