### PR TITLE
Problem: gRPC endpoints not supporting ibc-go 2.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,15 +33,21 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.44"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61604a8f862e1d5c3229fdd78f8b02c68dcf73a4c4b05fd636d12240aaa242c1"
+checksum = "ee10e43ae4a853c0a3591d4e2ada1719e553be18199d9da9d4a83f5927c2f5c7"
 
 [[package]]
 name = "arrayvec"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
+
+[[package]]
+name = "arrayvec"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
 
 [[package]]
 name = "async-stream"
@@ -136,6 +142,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bitvec"
+version = "0.20.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7774144344a4faa177370406a7ff5f1da24303817368584c6206c8303eb07848"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -167,6 +185,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f1e260c3a9040a7c19a12468758f4c16f31a81a1fe087482be9570ec864bb6c"
 
 [[package]]
+name = "byte-slice-cast"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c751592b77c499e7bce34d99d67c2c11bdc0574e9a488ddade14150a4698"
+
+[[package]]
 name = "byteorder"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -180,9 +204,9 @@ checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
 
 [[package]]
 name = "cc"
-version = "1.0.71"
+version = "1.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79c2681d6594606957bbb8631c4b90a7fcaaa72cdb714743a437b156d6a7eedd"
+checksum = "22a9137b95ea06864e018375b72adfb7db6e6f68cfc8df5a04d00288050485ee"
 
 [[package]]
 name = "cfg-if"
@@ -365,6 +389,12 @@ dependencies = [
  "cfg-if 1.0.0",
  "lazy_static",
 ]
+
+[[package]]
+name = "crunchy"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "crypto-bigint"
@@ -558,6 +588,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fixed-hash"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcf0ed7fe52a17a03854ec54a9f76d6d84508d1c0e66bc1793301c73fc8493c"
+dependencies = [
+ "byteorder",
+ "rand 0.8.4",
+ "rustc-hex",
+ "static_assertions",
+]
+
+[[package]]
 name = "fixedbitset"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -603,6 +645,12 @@ dependencies = [
  "matches",
  "percent-encoding",
 ]
+
+[[package]]
+name = "funty"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fed34cd105917e91daa4da6b3728c47b068749d6a62c59811f06ed2ac71d9da7"
 
 [[package]]
 name = "futures"
@@ -738,7 +786,7 @@ checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "wasi 0.10.0+wasi-snapshot-preview1",
+ "wasi 0.10.2+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -1008,6 +1056,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "impl-codec"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "161ebdfec3c8e3b52bf61c4f3550a1eea4f9579d10dc1b936f3171ebdcd6c443"
+dependencies = [
+ "parity-scale-codec",
+]
+
+[[package]]
+name = "impl-serde"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4551f042f3438e64dbd6226b20527fc84a6e1fe65688b58746a2f53623f25f5c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "impl-trait-for-tuples"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5dacb10c5b3bb92d46ba347505a9041e676bb20ad220101326bffb0c93031ee"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "indenter"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1083,9 +1160,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.105"
+version = "0.2.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "869d572136620d55835903746bcb5cdc54cb2851fd0aeec53220b4bb65ef3013"
+checksum = "fbe5e23404da5b4f555ef85ebed98fb4083e55a00c317800bc2a50ede9f3d219"
 
 [[package]]
 name = "libloading"
@@ -1163,9 +1240,9 @@ checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
 
 [[package]]
 name = "minimal-lexical"
-version = "0.1.4"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c64630dcdd71f1a64c435f54885086a0de5d6a12d104d69b165fb7d5286d677"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "mio"
@@ -1229,9 +1306,9 @@ dependencies = [
 
 [[package]]
 name = "nom"
-version = "7.0.0"
+version = "7.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ffd9d26838a953b4af82cbeb9f1592c6798916983959be223a7124e992742c1"
+checksum = "1b1d11e1ef389c76fe5b81bcaf2ea32cf88b62bc494e19f493d0b30e7a930109"
 dependencies = [
  "memchr",
  "minimal-lexical",
@@ -1249,9 +1326,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74e768dff5fb39a41b3bcd30bb25cf989706c90d028d1ad71971987aa309d535"
+checksum = "f93ab6289c7b344a8a9f60f88d80aa20032336fe78da341afc91c8a2341fc75f"
 dependencies = [
  "autocfg",
  "num-integer",
@@ -1325,9 +1402,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
-version = "0.10.37"
+version = "0.10.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bc6b9e4403633698352880b22cbe2f0e45dd0177f6fabe4585536e56a3e4f75"
+checksum = "0c7ae222234c30df141154f159066c5093ff73b63204dcda7121eb082fc56a95"
 dependencies = [
  "bitflags",
  "cfg-if 1.0.0",
@@ -1345,15 +1422,41 @@ checksum = "28988d872ab76095a6e6ac88d99b54fd267702734fd7ffe610ca27f533ddb95a"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.68"
+version = "0.9.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c571f25d3f66dd427e417cebf73dbe2361d6125cf6e3a70d143fdf97c9f5150"
+checksum = "c6517987b3f8226b5da3661dad65ff7f300cc59fb5ea8333ca191fc65fde3edf"
 dependencies = [
  "autocfg",
  "cc",
  "libc",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "parity-scale-codec"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "373b1a4c1338d9cd3d1fa53b3a11bdab5ab6bd80a20f7f7becd76953ae2be909"
+dependencies = [
+ "arrayvec 0.7.2",
+ "bitvec",
+ "byte-slice-cast",
+ "impl-trait-for-tuples",
+ "parity-scale-codec-derive",
+ "serde",
+]
+
+[[package]]
+name = "parity-scale-codec-derive"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1557010476e0595c9b568d16dcfb81b93cdeb157612726f5170d31aa707bed27"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1383,9 +1486,9 @@ dependencies = [
 
 [[package]]
 name = "paste"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acbf547ad0c65e31259204bd90935776d1c693cec2f4ff7abb7a1bbbd40dfe58"
+checksum = "0744126afe1a6dd7f394cb50a716dbe086cb06e255e53d8d0185d82828358fb5"
 
 [[package]]
 name = "pbkdf2"
@@ -1494,6 +1597,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed0cfbc8191465bed66e1718596ee0b0b35d5ee1f41c5df2189d0fe8bde535ba"
 
 [[package]]
+name = "primitive-types"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05e4722c697a58a99d5d06a08c30821d7c082a4632198de1eaa5a6c22ef42373"
+dependencies = [
+ "fixed-hash",
+ "impl-codec",
+ "impl-serde",
+ "uint",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebace6889caf889b4d3f76becee12e90353f2b8c7d875534a71e5742f8f6f83"
+dependencies = [
+ "thiserror",
+ "toml",
+]
+
+[[package]]
 name = "proc-macro-error"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1599,6 +1724,12 @@ checksum = "38bc8cc6a5f2e3655e0899c1b848643b2562f853f114bfec7be120678e3ace05"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "radium"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "643f8f41a8ebc4c5dc4515c82bb8abd397b527fc20fd681b7c011c2aee5d44fb"
 
 [[package]]
 name = "rand"
@@ -1758,10 +1889,16 @@ version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "353775f96a1f400edcca737f843cb201af3645912e741e64456a257c770173e8"
 dependencies = [
- "arrayvec",
+ "arrayvec 0.5.2",
  "num-traits",
  "serde",
 ]
+
+[[package]]
+name = "rustc-hex"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e75f6a532d0fd9f7f13144f392b6ad56a32696bfcd9c78f797f16bbb6f072d6"
 
 [[package]]
 name = "rustls"
@@ -1893,9 +2030,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.68"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f690853975602e1bfe1ccbf50504d67174e3bcf340f23b5ea9992e0587a52d8"
+checksum = "e466864e431129c7e0d3476b92f20458e5879919a0596c6472738d9fa2d342f8"
 dependencies = [
  "indexmap",
  "itoa",
@@ -2000,6 +2137,7 @@ dependencies = [
  "libloading",
  "log",
  "num-rational",
+ "primitive-types",
  "prost",
  "prost-build",
  "prost-types",
@@ -2027,6 +2165,7 @@ dependencies = [
  "hex",
  "k256",
  "num-rational",
+ "primitive-types",
  "prost",
  "prost-types",
  "rand 0.8.4",
@@ -2262,6 +2401,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
 name = "tempfile"
 version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2430,9 +2575,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f83b2a3d4d9091d0abd7eba4dc2710b1718583bd4d8992e2190720ea38f391f7"
+checksum = "2c1c1d5a42b6245520c249549ec267180beaffcc0615401ac8e31853d4b6d8d2"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -2445,9 +2590,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.12.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2c2416fdedca8443ae44b4527de1ea633af61d8f7169ffa6e72c5b53d24efcc"
+checksum = "588b2d10a336da58d877567cd8fb8a14b463e2104910f8132cd054b4b96e29ee"
 dependencies = [
  "autocfg",
  "bytes",
@@ -2472,9 +2617,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2dd85aeaba7b68df939bd357c6afb36c87951be9e80bf9c859f2fc3e9fca0fd"
+checksum = "114383b041aa6212c579467afa0075fbbdd0718de036100bc0ba7961d8cb9095"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2504,9 +2649,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b2f3f698253f03119ac0102beaa64f67a67e08074d03a22d18784104543727f"
+checksum = "50145484efff8818b5ccd256697f36863f587da82cf8b409c53adf1e840798e3"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -2515,9 +2660,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.6.8"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d3725d3efa29485e87311c5b699de63cde14b00ed4d256b8318aa30ca452cd"
+checksum = "9e99e1983e5d376cd8eb4b66604d2e99e79f5bd988c3055891dcd8c9e2604cc0"
 dependencies = [
  "bytes",
  "futures-core",
@@ -2670,6 +2815,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b63708a265f51345575b27fe43f9500ad611579e764c79edbc2037b1121959ec"
 
 [[package]]
+name = "uint"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6470ab50f482bde894a037a57064480a246dbfdd5960bd65a44824693f08da5f"
+dependencies = [
+ "byteorder",
+ "crunchy",
+ "hex",
+ "static_assertions",
+]
+
+[[package]]
 name = "unicode-bidi"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2785,9 +2942,9 @@ checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi"
-version = "0.10.0+wasi-snapshot-preview1"
+version = "0.10.2+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
+checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "wasm-bindgen"
@@ -2885,9 +3042,9 @@ dependencies = [
 
 [[package]]
 name = "whoami"
-version = "1.1.5"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "483a59fee1a93fec90eb08bc2eb4315ef10f4ebc478b3a5fadc969819cb66117"
+checksum = "c33ac5ee236a4efbf2c98967e12c6cc0c51d93a744159a52957ba206ae6ef5f7"
 dependencies = [
  "wasm-bindgen",
  "web-sys",
@@ -2925,19 +3082,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
-name = "zeroize"
-version = "1.4.2"
+name = "wyz"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf68b08513768deaa790264a7fac27a58cbf2705cfcdc9448362229217d7e970"
+checksum = "85e60b0d1b5f99db2556934e21937020776a5d31520bf169e851ac44e6420214"
+
+[[package]]
+name = "zeroize"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d68d9dcec5f9b43a30d38c49f91dfedfaac384cb8f085faca366c26207dd1619"
 dependencies = [
  "zeroize_derive",
 ]
 
 [[package]]
 name = "zeroize_derive"
-version = "1.2.0"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdff2024a851a322b08f179173ae2ba620445aef1e838f0c196820eade4ae0c7"
+checksum = "65f1a51723ec88c66d5d1fe80c841f17f63587d6691901d66be9bec6c3b51f73"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/event-hooks/stdout-logger/Cargo.toml
+++ b/event-hooks/stdout-logger/Cargo.toml
@@ -9,6 +9,6 @@ edition = "2021"
 crate-type = ["dylib"]
 
 [dependencies]
-anyhow = "1.0.44"
+anyhow = "1.0.45"
 async-trait = "0.1.51"
 solo-machine-core = { path = "../../solo-machine-core" }

--- a/signers/mnemonic-signer/Cargo.toml
+++ b/signers/mnemonic-signer/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 crate-type = ["dylib"]
 
 [dependencies]
-anyhow = "1.0.44"
+anyhow = "1.0.45"
 async-trait = "0.1.51"
 bip32 = { version = "0.2.2", features = ["bip39"] }
 k256 = { version = "0.9.6", features = ["ecdsa"] }

--- a/solo-machine-core/Cargo.toml
+++ b/solo-machine-core/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = "1.0.44"
+anyhow = "1.0.45"
 async-trait = "0.1.51"
 bech32 = "0.8.1"
 chrono = { version = "0.4.19", default-features = false }
@@ -16,6 +16,7 @@ ed25519-dalek = { version = "1.0.1", features = ["serde"] }
 hex = { version = "0.4.3", features = ["serde"] }
 k256 = { version = "0.9.6", features = ["ecdsa"] }
 num-rational = { version = "0.4.0", features = ["serde"] }
+primitive-types = { version = "0.10.1", features = ["serde"] }
 prost = "0.9.0"
 prost-types = "0.9.0"
 rand = "0.8.4"
@@ -23,7 +24,7 @@ regex = "1.5.4"
 ripemd160 = "0.9.1"
 rust_decimal = "1.17.0"
 serde = { version = "1.0.130", features = ["derive"] }
-serde_json = "1.0.68"
+serde_json = "1.0.69"
 sha2 = "0.9.8"
 sha3 = { version = "0.9.1", optional = true }
 sqlx = { version = "0.5.9", features = [
@@ -36,7 +37,7 @@ sqlx = { version = "0.5.9", features = [
 tendermint = "0.23.0"
 tendermint-light-client = "0.23.0"
 tendermint-rpc = { version = "0.23.0", features = ["http-client"] }
-tokio = { version = "1.12.0", features = ["sync"] }
+tokio = { version = "1.13.0", features = ["sync"] }
 tonic = { version = "0.6.1", features = ["tls", "tls-roots"] }
 urlencoding = "2.1.0"
 

--- a/solo-machine-core/src/event.rs
+++ b/solo-machine-core/src/event.rs
@@ -2,6 +2,7 @@
 mod event_handler;
 
 use anyhow::{anyhow, Result};
+use primitive_types::U256;
 use serde::{Deserialize, Serialize};
 use tokio::sync::mpsc::UnboundedSender;
 
@@ -28,7 +29,7 @@ pub enum Event {
         /// Address of account on IBC enabled chain
         to_address: String,
         /// Amount of tokens minted
-        amount: u64,
+        amount: U256,
         /// Denom of tokens minted
         denom: Identifier,
         /// Hash of transaction on IBC enabled chain (in hex)
@@ -43,7 +44,7 @@ pub enum Event {
         /// Address of account on IBC enabled chain
         from_address: String,
         /// Amount of tokens minted
-        amount: u64,
+        amount: U256,
         /// Denom of tokens minted
         denom: Identifier,
         /// Hash of transaction on IBC enabled chain (in hex)

--- a/solo-machine-core/src/service/ibc_service.rs
+++ b/solo-machine-core/src/service/ibc_service.rs
@@ -13,6 +13,7 @@ use cosmos_sdk_proto::ibc::core::{
         Version as ConnectionVersion,
     },
 };
+use primitive_types::U256;
 use sqlx::{Executor, Transaction};
 use tendermint::{
     abci::{
@@ -456,7 +457,7 @@ impl IbcService {
         signer: impl Signer,
         chain_id: ChainId,
         request_id: Option<String>,
-        amount: u64,
+        amount: U256,
         denom: Identifier,
         receiver: Option<String>,
         memo: String,
@@ -556,7 +557,7 @@ impl IbcService {
         signer: impl Signer,
         chain_id: ChainId,
         request_id: Option<String>,
-        amount: u64,
+        amount: U256,
         denom: Identifier,
         memo: String,
     ) -> Result<String> {

--- a/solo-machine-core/src/transaction_builder.rs
+++ b/solo-machine-core/src/transaction_builder.rs
@@ -56,6 +56,7 @@ use cosmos_sdk_proto::{
         },
     },
 };
+use primitive_types::U256;
 use prost_types::{Any, Duration};
 use serde::Serialize;
 use serde_json::json;
@@ -403,7 +404,7 @@ pub async fn msg_token_send<C>(
     signer: impl Signer,
     rpc_client: &C,
     chain: &mut Chain,
-    amount: u64,
+    amount: U256,
     denom: &Identifier,
     receiver: String,
     memo: String,
@@ -480,7 +481,7 @@ where
 pub async fn msg_token_receive(
     signer: impl Signer,
     chain: &Chain,
-    amount: u64,
+    amount: U256,
     denom: &Identifier,
     receiver: String,
     memo: String,

--- a/solo-machine/Cargo.toml
+++ b/solo-machine/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = "1.0.44"
+anyhow = "1.0.45"
 async-trait = "0.1.51"
 bip32 = { version = "0.2.2", features = ["bip39"] }
 cli-table = { version = "0.4.6", default-features = false, features = [
@@ -21,17 +21,18 @@ k256 = { version = "0.9.6", features = ["ecdsa"] }
 libloading = "0.7.1"
 log = "0.4.14"
 num-rational = "0.4.0"
+primitive-types = "0.10.1"
 prost = "0.9.0"
 prost-types = "0.9.0"
 rust_decimal = "1.17.0"
-serde_json = "1.0.68"
+serde_json = "1.0.69"
 solo-machine-core = { path = "../solo-machine-core", features = [
     "solomachine-v2",
 ] }
 structopt = "0.3.25"
 tendermint = "0.23.0"
 termcolor = "1.1.2"
-tokio = { version = "1.12.0", features = ["fs", "macros", "rt-multi-thread"] }
+tokio = { version = "1.13.0", features = ["fs", "macros", "rt-multi-thread"] }
 tonic = { version = "0.6.1", features = ["tls", "tls-roots"] }
 
 [features]

--- a/solo-machine/proto/ibc.proto
+++ b/solo-machine/proto/ibc.proto
@@ -42,7 +42,7 @@ message MintRequest {
     // Memo value to be used in cosmos sdk transaction
     optional string memo = 3;
     // Amount of tokens to be sent
-    uint64 amount = 4;
+    string amount = 4;
     // Denom of tokens to be sent
     string denom = 5;
     // Receiver address on IBC enabled chain (if this is not provided, tokens will be sent to signer's address)
@@ -62,7 +62,7 @@ message BurnRequest {
     // Memo value to be used in cosmos sdk transaction
     optional string memo = 3;
     // Amount of tokens to be sent
-    uint64 amount = 4;
+    string amount = 4;
     // Denom of tokens to be sent
     string denom = 5;
 }
@@ -109,7 +109,7 @@ message Operation {
     // Denom of account
     string denom = 4;
     // Amount associated with operation
-    uint64 amount = 5;
+    string amount = 5;
     // Type of operation (e.g., mint, burn, send, receive)
     string operation_type = 6;
     // On-chain transaction hash (in hex)

--- a/solo-machine/src/command/ibc.rs
+++ b/solo-machine/src/command/ibc.rs
@@ -3,6 +3,7 @@ use cli_table::{
     format::Justify, print_stdout, Cell, Color, ColorChoice, Row, RowStruct, Style, Table,
 };
 use k256::ecdsa::VerifyingKey;
+use primitive_types::U256;
 use serde_json::json;
 use solo_machine_core::{
     cosmos::crypto::{PublicKey, PublicKeyAlgo},
@@ -62,7 +63,7 @@ pub enum IbcCommand {
         /// Chain ID of IBC enabled chain
         chain_id: ChainId,
         /// Amount to send to IBC enabled chain
-        amount: u64,
+        amount: U256,
         /// Denom of tokens to send to IBC enabled chain
         denom: Identifier,
         /// Optional receiver address (if this is not provided, tokens will be sent to signer's address)
@@ -84,7 +85,7 @@ pub enum IbcCommand {
         /// Chain ID of IBC enabled chain
         chain_id: ChainId,
         /// Amount to receive from IBC enabled chain
-        amount: u64,
+        amount: U256,
         /// Denom of tokens to receive from IBC enabled chain
         denom: Identifier,
         /// Optional memo to include in transactions

--- a/solo-machine/src/server/ibc.rs
+++ b/solo-machine/src/server/ibc.rs
@@ -3,6 +3,7 @@ tonic::include_proto!("ibc");
 use std::time::SystemTime;
 
 use k256::ecdsa::VerifyingKey;
+use primitive_types::U256;
 use solo_machine_core::{
     cosmos::crypto::{PublicKey, PublicKeyAlgo},
     ibc::core::ics24_host::identifier::ChainId,
@@ -72,7 +73,8 @@ where
             .map_err(|err: anyhow::Error| Status::invalid_argument(err.to_string()))?;
         let request_id = request.request_id;
         let memo = request.memo.unwrap_or_else(|| DEFAULT_MEMO.to_owned());
-        let amount = request.amount;
+        let amount = U256::from_dec_str(&request.amount)
+            .map_err(|err| Status::invalid_argument(err.to_string()))?;
         let denom = request
             .denom
             .parse()
@@ -108,7 +110,8 @@ where
             .map_err(|err: anyhow::Error| Status::invalid_argument(err.to_string()))?;
         let request_id = request.request_id;
         let memo = request.memo.unwrap_or_else(|| DEFAULT_MEMO.to_owned());
-        let amount = request.amount;
+        let amount = U256::from_dec_str(&request.amount)
+            .map_err(|err| Status::invalid_argument(err.to_string()))?;
         let denom = request
             .denom
             .parse()
@@ -197,7 +200,7 @@ where
                     request_id: op.request_id,
                     address: op.address,
                     denom: op.denom.to_string(),
-                    amount: op.amount,
+                    amount: op.amount.to_string(),
                     operation_type: op.operation_type.to_string(),
                     transaction_hash: op.transaction_hash,
                     created_at: Some(SystemTime::from(op.created_at).into()),


### PR DESCRIPTION
Solution: Changed amounts in solo machine to `U256`. Fixes #78.